### PR TITLE
Fix alignFace out-of-bounds error

### DIFF
--- a/src/main/java/com/simprints/simface/core/Utils.kt
+++ b/src/main/java/com/simprints/simface/core/Utils.kt
@@ -1,5 +1,6 @@
 package com.simprints.simface.core
 
+import android.graphics.Rect
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -28,4 +29,20 @@ internal object Utils {
         val floatBuffer = byteBuffer.asFloatBuffer()
         return FloatArray(floatBuffer.remaining()).apply { floatBuffer.get(this) }
     }
+
+    /**
+     * Clamps the rectangle to the bounds of the image.
+     *
+     * @param width The width of the image.
+     * @param height The height of the image.
+     * @return A new rectangle that is clamped to the bounds of the image.
+     */
+    internal fun Rect.clampToBounds(width: Int, height: Int): Rect {
+        return Rect(
+            left.coerceAtLeast(0),
+            top.coerceAtLeast(0),
+            right.coerceAtMost(width),
+            bottom.coerceAtMost(height)
+        )
+    }    
 }

--- a/src/main/java/com/simprints/simface/quality/MlKitFaceDetectionProcessor.kt
+++ b/src/main/java/com/simprints/simface/quality/MlKitFaceDetectionProcessor.kt
@@ -6,6 +6,7 @@ import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.face.Face
 import com.simprints.simface.core.MLModelManager
 import com.simprints.simface.core.SimFace
+import com.simprints.simface.core.Utils.clampToBounds
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -29,7 +30,10 @@ internal class MlKitFaceDetectionProcessor() : FaceDetectionProcessor {
                     val simFace = SimFace(
                         sourceWidth = image.width,
                         sourceHeight = image.height,
-                        absoluteBoundingBox = face.boundingBox,
+                        absoluteBoundingBox = face.boundingBox.clampToBounds(
+                            image.width,
+                            image.height
+                        ),
                         yaw = face.headEulerAngleY,
                         roll = face.headEulerAngleZ,
                         quality = calculateFaceQuality(face, image.width, image.height)
@@ -57,7 +61,10 @@ internal class MlKitFaceDetectionProcessor() : FaceDetectionProcessor {
                         val simFace = SimFace(
                             sourceWidth = image.width,
                             sourceHeight = image.height,
-                            absoluteBoundingBox = face.boundingBox,
+                            absoluteBoundingBox = face.boundingBox.clampToBounds(
+                                image.width,
+                                image.height
+                            ),
                             yaw = face.headEulerAngleY,
                             roll = face.headEulerAngleZ,
                             quality = calculateFaceQuality(face, image.width, image.height)


### PR DESCRIPTION
# Description

The alignFace function throws an `IllegalArgumentException: The provided faceBoundingBox is out of the Bitmap bounds` error when MLKit detects a face which extends slightly outside of the bounds of an image (this is an expected behaviour from MLKit). 

We now clamp the bounding box output such that it fits the image and cropping can occur free of error.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Tested manually with multiple out-of-bounds and normal face images

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules